### PR TITLE
fix text email link

### DIFF
--- a/accounts/mailer/templates.py
+++ b/accounts/mailer/templates.py
@@ -5,16 +5,16 @@ Distributed under the MIT License. See LICENSE.txt for more info.
 # Templates for different emails
 VERIFY_EMAIL_ADDRESS = dict()
 VERIFY_EMAIL_ADDRESS['subject'] = '[BILBY-WEB] Please verify your email address'
-VERIFY_EMAIL_ADDRESS['message'] = '<p>Dear {{first_name}} {{last_name}}</p>' \
+VERIFY_EMAIL_ADDRESS['message'] = '<p>Dear {{first_name}} {{last_name}}: </p>' \
                                   '<p>We have received a new account request with our BILBY-WEB system from this ' \
                                   'email address. Please verify your email address by clicking on the following ' \
-                                  '<a href="{{link}}" target="_blank">link</a>:</p>' \
-                                  '<p><a href="{{link}}" target="_blank">{{link}}</a></p>' \
+                                  '<a href="{{link}}" target="_blank">link</a>: </p>' \
+                                  '<p><a href="{{link}}" target="_blank">{{link}}</a> </p>' \
                                   '<p>If you believe that the email has been sent by mistake or you have not ' \
-                                  'requested for an account please <strong>do not</strong> click on the link.</p>' \
+                                  'requested for an account please <strong>do not</strong> click on the link. </p>' \
                                   '<p>Alternatively you can report this incident to <a ' \
                                   'href="mailto:paul.lasky@monash.edu" target="_top">paul.lasky@monash.edu</a> for ' \
-                                  'investigation.</p>' \
-                                  '<p>&nbsp;</p>' \
-                                  '<p>Regards,</p>' \
+                                  'investigation. </p>' \
+                                  '<p> </p>' \
+                                  '<p>Regards, </p>' \
                                   '<p>BILBY Team</p>'


### PR DESCRIPTION
Extra characters were being added to the code while viewing in text mode. By adding spaces, problem is fixed.